### PR TITLE
Update hubot-hipchat adapter to fix crash on disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "hubot-google-images": "^0.2.6",
     "hubot-help": "^0.2.0",
     "hubot-heroku-keepalive": "^1.0.2",
-    "hubot-hipchat": "^2.12.0-6",
+    "hubot-hipchat": "https://github.com/hipchat/hubot-hipchat#47c9187ffd26bc70cf0dbfd011fcecc7d023efec",
     "hubot-irc": "^0.2.8",
     "hubot-maps": "0.0.2",
     "hubot-newrelic2": "0.2.5",


### PR DESCRIPTION
See https://github.com/hipchat/hubot-hipchat/pull/267

There has been no release containing the fix,
so we have to tell npm to pull the revision from the git repository.
